### PR TITLE
Update README.md

### DIFF
--- a/supported/solutions/autoscale/waf/README.md
+++ b/supported/solutions/autoscale/waf/README.md
@@ -36,7 +36,7 @@ This Readme file describes launching from the AWS Marketplace.  If you are using
 
 From the Marketplace: 
 - From the **For Region** list, select your Region. 
-- From the **Delivery Methods** list, select **Auto Scale via CFT**
+- From the **Delivery Methods** list, select **CloudFormation Stack**
 - Click **Continue**
 - Select either the **Hourly** or **Yearly** Subscription Term.
 - Select the appropriate version.


### PR DESCRIPTION
From market place in AWS the delivery method is called "CloudFormation Stack", I think maybe we just had a default name in there, which can be confusing.

verify by going to was marketplace, here are the options:

Delivery Method
 Amazon Machine Image
 CloudFormation Stack
 SaaS

@<reviewer_id>

#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?
fixes readme for correct wording

#### Where should the reviewer start?
AWS market place

#### Any background context?
with the upcoming release to marketplace and a reference to this readme having the documentation correct will save confusing of people looking for a different "Delivery Method"