### PR TITLE
Avoid processing IPv6 Self IPs

### DIFF
--- a/iApps/f5.aws_advanced_ha.v1.4.0rc2.tmpl
+++ b/iApps/f5.aws_advanced_ha.v1.4.0rc2.tmpl
@@ -3333,6 +3333,9 @@ def getSelfIPFromVLAN(interfaceVLAN) :
             selfIP = ''
             foundVLAN = False
         elif len(tokens) == 2 and tokens[0] == 'address' :
+            if ":" in tokens[1] :
+                logLTM.log(logging.DEBUG, "Skipping IPv6 Self IP: " + tokens[1])
+                continue
             selfIP = tokens[1]
             if foundVLAN :
                 break


### PR DESCRIPTION
Modified getSelfIPFromVLAN to avoid issues with downstream scripts processing IPv6 addresses. Currently, IPv6 addresses are not supported, thus this fix bypasses them.