### PR TITLE
Skip processing IPv6 addresses

### DIFF
--- a/iApps/f5.aws_advanced_ha.v1.2.0rc1.tmpl
+++ b/iApps/f5.aws_advanced_ha.v1.2.0rc1.tmpl
@@ -2079,6 +2079,9 @@ def getSelfIPFromVLAN(interfaceVLAN) :
             selfIP = ''
             foundVLAN = False
         elif len(tokens) == 2 and tokens[0] == 'address' :
+            if ":" in tokens[1] :
+                logLTM.log(logging.DEBUG, "Skipping IPv6 Self IP: " + tokens[1])
+                continue
             selfIP = tokens[1]
             if foundVLAN :
                 break

--- a/iApps/f5.aws_advanced_ha.v1.3.0rc1.tmpl
+++ b/iApps/f5.aws_advanced_ha.v1.3.0rc1.tmpl
@@ -2344,6 +2344,9 @@ def getSelfIPFromVLAN(interfaceVLAN) :
             selfIP = ''
             foundVLAN = False
         elif len(tokens) == 2 and tokens[0] == 'address' :
+            if ":" in tokens[1] :
+                logLTM.log(logging.DEBUG, "Skipping IPv6 Self IP: " + tokens[1])
+                continue
             selfIP = tokens[1]
             if foundVLAN :
                 break

--- a/iApps/f5.aws_advanced_ha.v1.4.0rc1.tmpl
+++ b/iApps/f5.aws_advanced_ha.v1.4.0rc1.tmpl
@@ -2460,6 +2460,9 @@ def getSelfIPFromVLAN(interfaceVLAN) :
             selfIP = ''
             foundVLAN = False
         elif len(tokens) == 2 and tokens[0] == 'address' :
+            if ":" in tokens[1] :
+                logLTM.log(logging.DEBUG, "Skipping IPv6 Self IP: " + tokens[1])
+                continue
             selfIP = tokens[1]
             if foundVLAN :
                 break

--- a/iApps/f5.aws_advanced_ha.v1.4.0rc2.tmpl
+++ b/iApps/f5.aws_advanced_ha.v1.4.0rc2.tmpl
@@ -2460,6 +2460,9 @@ def getSelfIPFromVLAN(interfaceVLAN) :
             selfIP = ''
             foundVLAN = False
         elif len(tokens) == 2 and tokens[0] == 'address' :
+            if ":" in tokens[1] :
+                logLTM.log(logging.DEBUG, "Skipping IPv6 Self IP: " + tokens[1])
+                continue
             selfIP = tokens[1]
             if foundVLAN :
                 break


### PR DESCRIPTION
Bypass processing of IPv6 functions which cause AWS Failover issues in downstream scripts. When multiple Self IPs are present, the unsupported IPv6 address can sometimes be picked up as the IP to be used in AWS API calls to migrate network configuration. 